### PR TITLE
feature/AABB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ engine/build/
 # testing folder
 testing/
 
+# dev-tool folder
+tools/
+
 # IDE and OS files
 .vscode/
 .DS_Store

--- a/engine/include/collisions/AABB.hpp
+++ b/engine/include/collisions/AABB.hpp
@@ -1,0 +1,26 @@
+//Class defenition for Axis Aligined Bounding Boxes (AABB)
+
+#ifndef AABB_HPP
+#define AABB_HPP
+
+#include "core/Vector2.hpp"
+
+class AABB
+{
+public:
+    //Constructor to set mins and maxes
+    AABB(Vector2 min, Vector2 max);
+
+    //Getters for member variables
+    Vector2 getMin();
+    Vector2 getMax();
+
+private:
+    //Min x and y
+    Vector2 m_min;
+
+    //Max x and y
+    Vector2 m_max;
+};
+
+#endif

--- a/engine/include/collisions/AABB.hpp
+++ b/engine/include/collisions/AABB.hpp
@@ -12,8 +12,12 @@ public:
     AABB(Vector2 min, Vector2 max);
 
     //Getters for member variables
-    Vector2 getMin();
-    Vector2 getMax();
+    Vector2 getMin() const;
+    Vector2 getMax() const;
+
+    //Setters for member variables
+    void setMin(const Vector2& newMin);
+    void setMax(const Vector2& newMax);
 
 private:
     //Min x and y

--- a/engine/include/collisions/CircleCollider.hpp
+++ b/engine/include/collisions/CircleCollider.hpp
@@ -12,6 +12,9 @@ private:
     //Radius of the circle
     float radius;
 
+    //Update AABB mins and maxes
+    virtual void updateAABB() override;
+
 public:
     //Constructor to set radius and collider type
     CircleCollider(float initialRadius, ColliderType type);

--- a/engine/include/collisions/Collider.hpp
+++ b/engine/include/collisions/Collider.hpp
@@ -8,6 +8,7 @@
 
 #include "physics/PhysicsBody.hpp"
 #include "core/Vector2.hpp"
+#include "collisions/AABB.hpp"
 
 enum class ColliderShape
 {
@@ -41,6 +42,12 @@ protected:
     //Type of collider, solid or trigger
     ColliderType type;
 
+    //Bounding box for broad collision detection
+    AABB* boundingBox;
+
+    //Update AABB mins and maxes
+    virtual void updateAABB();
+
 public:
     //Constructor to set shape and collider type
     Collider(ColliderShape shapeType, ColliderType type);
@@ -53,6 +60,7 @@ public:
     PhysicsBody* getParent() const;
     ColliderShape getShape() const;
     ColliderType getType() const;
+    AABB* getAABB() const;
 
     //Setters for member variables
     void setPosition(const Vector2& newPosition);

--- a/engine/include/collisions/Collider.hpp
+++ b/engine/include/collisions/Collider.hpp
@@ -46,13 +46,13 @@ protected:
     AABB* boundingBox;
 
     //Update AABB mins and maxes
-    virtual void updateAABB();
+    virtual void updateAABB() = 0;
 
 public:
     //Constructor to set shape and collider type
     Collider(ColliderShape shapeType, ColliderType type);
 
-    virtual ~Collider() = default;
+    virtual ~Collider();
 
     //Getters for member variables
     const Vector2& getPosition() const;

--- a/engine/include/collisions/CollisionDetection.hpp
+++ b/engine/include/collisions/CollisionDetection.hpp
@@ -4,12 +4,16 @@
 #ifndef COLLISION_DETECTION_HPP
 #define COLLISION_DETECTION_HPP
 
+#include "collisions/AABB.hpp"
 #include "collisions/RectCollider.hpp"
 #include "collisions/CircleCollider.hpp"
 #include "collisions/Collision.hpp"
 
 namespace CollisionDetection
 {
+    //Checks if two AABBs are overlapping
+    bool checkAABBvsAABB(AABB* boxA, AABB* boxB);
+
     //Sorts into respective function based on body shapes
     Collision* checkCollision(PhysicsBody* bodyA, PhysicsBody* bodyB);
 

--- a/engine/include/collisions/RectCollider.hpp
+++ b/engine/include/collisions/RectCollider.hpp
@@ -13,6 +13,9 @@ private:
     float width;
     float height;
 
+    //Update AABB mins and maxes
+    virtual void updateAABB() override;
+
 public:
     //Constructor to set dimensions and collider type
     RectCollider(Vector2 dimensions, ColliderType type);

--- a/engine/src/collisions/AABB.cpp
+++ b/engine/src/collisions/AABB.cpp
@@ -5,12 +5,23 @@ AABB::AABB(Vector2 min, Vector2 max)
     : m_min(min), m_max(max) {}
 
 //Getters for member variables
-Vector2 AABB::getMin()
+Vector2 AABB::getMin() const
 {
     return m_min;
 }
 
-Vector2 AABB::getMax()
+Vector2 AABB::getMax() const
 {
     return m_max;
+}
+
+//Setters for member variables
+void AABB::setMin(const Vector2& newMin)
+{
+    m_min = newMin;
+}
+
+void AABB::setMax(const Vector2& newMax)
+{
+    m_max = newMax;
 }

--- a/engine/src/collisions/AABB.cpp
+++ b/engine/src/collisions/AABB.cpp
@@ -1,0 +1,16 @@
+#include "collisions/AABB.hpp"
+
+//Constructor to set mins and maxes
+AABB::AABB(Vector2 min, Vector2 max)
+    : m_min(min), m_max(max) {}
+
+//Getters for member variables
+Vector2 AABB::getMin()
+{
+    return m_min;
+}
+
+Vector2 AABB::getMax()
+{
+    return m_max;
+}

--- a/engine/src/collisions/CircleCollider.cpp
+++ b/engine/src/collisions/CircleCollider.cpp
@@ -4,7 +4,11 @@
 
 //Constructor to set radius and collider type
 CircleCollider::CircleCollider(float initialRadius, ColliderType type)
-    : Collider(ColliderShape::Circle, type), radius(initialRadius) {}
+    : Collider(ColliderShape::Circle, type), radius(initialRadius)
+    {
+        //Create AABB to enclose circle shape
+        boundingBox = new AABB({position.x - radius, position.y + radius}, {position.x + radius, position.y - radius});
+    }
 
 //Getters for member variables
 float CircleCollider::getRadius() const
@@ -18,5 +22,13 @@ void CircleCollider::setRadius(float newRadius)
     if (radius >= 0)
     {
         radius = newRadius; //Ensure non-negative radius
+
+        updateAABB();
     }
+}
+
+void CircleCollider::updateAABB()
+{
+    boundingBox->setMin({position.x - radius, position.y + radius});
+    boundingBox->setMax({position.x + radius, position.y - radius});
 }

--- a/engine/src/collisions/CircleCollider.cpp
+++ b/engine/src/collisions/CircleCollider.cpp
@@ -7,7 +7,7 @@ CircleCollider::CircleCollider(float initialRadius, ColliderType type)
     : Collider(ColliderShape::Circle, type), radius(initialRadius)
     {
         //Create AABB to enclose circle shape
-        boundingBox = new AABB({position.x - radius, position.y + radius}, {position.x + radius, position.y - radius});
+        boundingBox = new AABB({position.x - radius, position.y - radius}, {position.x + radius, position.y + radius});
     }
 
 //Getters for member variables
@@ -29,6 +29,6 @@ void CircleCollider::setRadius(float newRadius)
 
 void CircleCollider::updateAABB()
 {
-    boundingBox->setMin({position.x - radius, position.y + radius});
-    boundingBox->setMax({position.x + radius, position.y - radius});
+    boundingBox->setMin({position.x - radius, position.y - radius});
+    boundingBox->setMax({position.x + radius, position.y + radius});
 }

--- a/engine/src/collisions/Collider.cpp
+++ b/engine/src/collisions/Collider.cpp
@@ -4,7 +4,7 @@
 
 //Constructor to set shape and collider type
 Collider::Collider(ColliderShape shapeType, ColliderType type)
-: parent(nullptr), position({0, 0}), offset({0, 0}), shape(shapeType), type(type) {}
+: parent(nullptr), position({0, 0}), offset({0, 0}), shape(shapeType), type(type), boundingBox(nullptr) {}
 
 //Getters for member variables
 const Vector2& Collider::getPosition() const
@@ -31,10 +31,17 @@ ColliderType Collider::getType() const
     return type;
 }
 
+AABB* Collider::getAABB() const
+{
+    return boundingBox;
+}
+
 //Setters for member variables
 void Collider::setPosition(const Vector2& newPosition)
 {
     position = newPosition;
+
+    updateAABB();
 }
 
 void Collider::setOffset(const Vector2& newOffest)

--- a/engine/src/collisions/Collider.cpp
+++ b/engine/src/collisions/Collider.cpp
@@ -6,6 +6,11 @@
 Collider::Collider(ColliderShape shapeType, ColliderType type)
 : parent(nullptr), position({0, 0}), offset({0, 0}), shape(shapeType), type(type), boundingBox(nullptr) {}
 
+Collider::~Collider()
+{
+    delete boundingBox;
+}
+
 //Getters for member variables
 const Vector2& Collider::getPosition() const
 {

--- a/engine/src/collisions/CollisionDetection.cpp
+++ b/engine/src/collisions/CollisionDetection.cpp
@@ -16,12 +16,12 @@ bool CollisionDetection::checkAABBvsAABB(AABB* boxA, AABB* boxB)
     Vector2 minB = boxB->getMin();
     Vector2 maxB = boxB->getMax();
 
-    //Exit with no intersection if found separated along an axis 
-    if(maxA.x < minB.x or minA.x > maxB.x) return false;
-    if(maxA.y < minB.y or minA.y > maxB.y) return false;
+    //Check for overlap
+    if (maxA.x > minB.x && minA.x < maxB.x && maxA.y > minB.y && minA.y < maxB.y)
+        return true;
 
-    //No separating axis found, therefor there is at least one overlapping axis 
-    return true;
+    //No overlap
+    return false;
 }
 
 //Sorts into respective function based on body shapes

--- a/engine/src/collisions/CollisionDetection.cpp
+++ b/engine/src/collisions/CollisionDetection.cpp
@@ -6,6 +6,24 @@
 
 struct Collision;
 
+//Checks if two AABBs are overlapping
+bool CollisionDetection::checkAABBvsAABB(AABB* boxA, AABB* boxB)
+{
+    //Get mins and maxes
+    Vector2 minA = boxA->getMin();
+    Vector2 maxA = boxA->getMax();
+
+    Vector2 minB = boxB->getMin();
+    Vector2 maxB = boxB->getMax();
+
+    //Exit with no intersection if found separated along an axis 
+    if(maxA.x < minB.x or minA.x > maxB.x) return false;
+    if(maxA.y < minB.y or minA.y > maxB.y) return false;
+
+    //No separating axis found, therefor there is at least one overlapping axis 
+    return true;
+}
+
 //Sorts into respective function based on body shapes
 Collision* CollisionDetection::checkCollision(PhysicsBody* bodyA, PhysicsBody* bodyB)
 {

--- a/engine/src/collisions/RectCollider.cpp
+++ b/engine/src/collisions/RectCollider.cpp
@@ -4,7 +4,11 @@
 
 //Constructor to set width and height of collider
 RectCollider::RectCollider(Vector2 dimensions, ColliderType type)
-    : Collider(ColliderShape::Rectangle, type), width(dimensions.x), height(dimensions.y) {}
+    : Collider(ColliderShape::Rectangle, type), width(dimensions.x), height(dimensions.y)
+    {
+        //Create AABB to enclose rectangle shape
+        boundingBox = new AABB({position.x - width / 2, position.y + height / 2}, {position.x + width / 2, position.y - height / 2});
+    }
 
 //Getters for member variables
 float RectCollider::getWidth() const
@@ -23,6 +27,7 @@ void RectCollider::setWidth(float newWidth)
     if (newWidth >= 0)
     {
         width = newWidth;
+        updateAABB();
     }
 }
 
@@ -31,5 +36,13 @@ void RectCollider::setHeight(float newHeight)
     if (newHeight >= 0)
     {
         height = newHeight;
+        updateAABB();
     }
+}
+
+//Update AABB mins and maxes
+void RectCollider::updateAABB()
+{
+    boundingBox->setMin({position.x - width / 2, position.y + height / 2});
+    boundingBox->setMax({position.x + width / 2, position.y - height / 2});
 }

--- a/engine/src/collisions/RectCollider.cpp
+++ b/engine/src/collisions/RectCollider.cpp
@@ -7,7 +7,7 @@ RectCollider::RectCollider(Vector2 dimensions, ColliderType type)
     : Collider(ColliderShape::Rectangle, type), width(dimensions.x), height(dimensions.y)
     {
         //Create AABB to enclose rectangle shape
-        boundingBox = new AABB({position.x - width / 2, position.y + height / 2}, {position.x + width / 2, position.y - height / 2});
+        boundingBox = new AABB({position.x - width / 2, position.y - height / 2}, {position.x + width / 2, position.y + height / 2});
     }
 
 //Getters for member variables
@@ -43,6 +43,6 @@ void RectCollider::setHeight(float newHeight)
 //Update AABB mins and maxes
 void RectCollider::updateAABB()
 {
-    boundingBox->setMin({position.x - width / 2, position.y + height / 2});
-    boundingBox->setMax({position.x + width / 2, position.y - height / 2});
+    boundingBox->setMin({position.x - width / 2, position.y - height / 2});
+    boundingBox->setMax({position.x + width / 2, position.y + height / 2});
 }

--- a/engine/src/core/Engine.cpp
+++ b/engine/src/core/Engine.cpp
@@ -146,11 +146,17 @@ void Engine::processCollisions()
                 if (colliderTypeA == ColliderType::Trigger || colliderTypeB == ColliderType::Trigger)
                     continue;
 
-                //If a collision is detected between the colliders, pass bodies to collision solver
+                //First check if AABBs are intersecting (Broad phase)
+                AABB* boundingBoxA = colliderA->getAABB();
+                AABB* boundingBoxB = colliderB->getAABB();
+
+                if (!CollisionDetection::checkAABBvsAABB(boundingBoxA, boundingBoxB)) continue;
+
+                //Check collision between colliders (Narrow phase)
                 Collision* collision = CollisionDetection::checkCollision(bodyA, bodyB);
                 if (collision)
                 {
-                    collisionSolver.addCollision(collision);
+                    collisionSolver.addCollision(collision); //Pass collision object to collision solver
                 }
             }
         }


### PR DESCRIPTION
Added AABBs to enclose all colliders. This allows the engine to first do a broad phase collision check with the AABBs before going onto a narrow phase collision check with their precise shapes. Time to detect collisions every frame dropped from roughly 8,000 microseconds to roughly 6,000 microseconds.