### PR TITLE
Refactor/structs

### DIFF
--- a/engine/include/collisions/AABB.hpp
+++ b/engine/include/collisions/AABB.hpp
@@ -1,30 +1,23 @@
-//Class defenition for Axis Aligined Bounding Boxes (AABB)
+//Struct defenition for Axis Aligined Bounding Boxes (AABB)
 
 #ifndef AABB_HPP
 #define AABB_HPP
 
 #include "core/Vector2.hpp"
 
-class AABB
+struct AABB
 {
-public:
-    //Constructor to set mins and maxes
-    AABB(Vector2 min, Vector2 max);
-
-    //Getters for member variables
-    Vector2 getMin() const;
-    Vector2 getMax() const;
-
-    //Setters for member variables
-    void setMin(const Vector2& newMin);
-    void setMax(const Vector2& newMax);
-
-private:
     //Min x and y
-    Vector2 m_min;
+    Vector2 min;
 
     //Max x and y
-    Vector2 m_max;
+    Vector2 max;
+
+    //Default constructor
+    AABB();
+
+    //Constructor to set mins and maxes
+    AABB(const Vector2& min, const Vector2& max);
 };
 
 #endif

--- a/engine/include/collisions/Collider.hpp
+++ b/engine/include/collisions/Collider.hpp
@@ -43,7 +43,7 @@ protected:
     ColliderType type;
 
     //Bounding box for broad collision detection
-    AABB* boundingBox;
+    AABB boundingBox;
 
     //Update AABB mins and maxes
     virtual void updateAABB() = 0;
@@ -60,7 +60,7 @@ public:
     PhysicsBody* getParent() const;
     ColliderShape getShape() const;
     ColliderType getType() const;
-    AABB* getAABB() const;
+    const AABB& getAABB() const;
 
     //Setters for member variables
     void setPosition(const Vector2& newPosition);

--- a/engine/include/collisions/CollisionDetection.hpp
+++ b/engine/include/collisions/CollisionDetection.hpp
@@ -12,7 +12,7 @@
 namespace CollisionDetection
 {
     //Checks if two AABBs are overlapping
-    bool checkAABBvsAABB(AABB* boxA, AABB* boxB);
+    bool checkAABBvsAABB(const AABB& boxA, const AABB& boxB);
 
     //Sorts into respective function based on body shapes
     Collision* checkCollision(PhysicsBody* bodyA, PhysicsBody* bodyB);

--- a/engine/include/core/Engine.hpp
+++ b/engine/include/core/Engine.hpp
@@ -99,6 +99,7 @@ public:
     //Returns the vector of physics bodies in the world
     const std::vector<PhysicsBody*>& getBodies() const;
 
+    //Returns a pointer to the world boundary
     WorldBoundary* getBoundary() const;
 };
 

--- a/engine/include/core/Vector2.hpp
+++ b/engine/include/core/Vector2.hpp
@@ -1,15 +1,14 @@
-//Class defentions for 2D vectors
+//Struct defention for 2D vectors
 //Stores an x and y value
 //Methods for normalizing, finding distance
 
-#ifndef Vector2_HPP
-#define Vector2_HPP
+#ifndef VECTOR2_HPP
+#define VECTOR2_HPP
 
 #include <cmath>
 
-class Vector2
+struct Vector2
 {
-public:
     //coordinates of the vector
     float x;
     float y;

--- a/engine/src/collisions/AABB.cpp
+++ b/engine/src/collisions/AABB.cpp
@@ -1,27 +1,8 @@
 #include "collisions/AABB.hpp"
 
+//Default constructor
+AABB::AABB() : min(Vector2()), max(Vector2()) {}
+
 //Constructor to set mins and maxes
-AABB::AABB(Vector2 min, Vector2 max)
-    : m_min(min), m_max(max) {}
-
-//Getters for member variables
-Vector2 AABB::getMin() const
-{
-    return m_min;
-}
-
-Vector2 AABB::getMax() const
-{
-    return m_max;
-}
-
-//Setters for member variables
-void AABB::setMin(const Vector2& newMin)
-{
-    m_min = newMin;
-}
-
-void AABB::setMax(const Vector2& newMax)
-{
-    m_max = newMax;
-}
+AABB::AABB(const Vector2& min, const Vector2& max)
+    : min(min), max(max) {}

--- a/engine/src/collisions/CircleCollider.cpp
+++ b/engine/src/collisions/CircleCollider.cpp
@@ -7,7 +7,7 @@ CircleCollider::CircleCollider(float initialRadius, ColliderType type)
     : Collider(ColliderShape::Circle, type), radius(initialRadius)
     {
         //Create AABB to enclose circle shape
-        boundingBox = new AABB({position.x - radius, position.y - radius}, {position.x + radius, position.y + radius});
+        boundingBox = AABB({position.x - radius, position.y - radius}, {position.x + radius, position.y + radius});
     }
 
 //Getters for member variables
@@ -29,6 +29,6 @@ void CircleCollider::setRadius(float newRadius)
 
 void CircleCollider::updateAABB()
 {
-    boundingBox->setMin({position.x - radius, position.y - radius});
-    boundingBox->setMax({position.x + radius, position.y + radius});
+    boundingBox.min = {position.x - radius, position.y - radius};
+    boundingBox.max = {position.x + radius, position.y + radius};
 }

--- a/engine/src/collisions/Collider.cpp
+++ b/engine/src/collisions/Collider.cpp
@@ -4,12 +4,10 @@
 
 //Constructor to set shape and collider type
 Collider::Collider(ColliderShape shapeType, ColliderType type)
-: parent(nullptr), position({0, 0}), offset({0, 0}), shape(shapeType), type(type), boundingBox(nullptr) {}
+: parent(nullptr), position({0, 0}), offset({0, 0}), shape(shapeType), type(type), boundingBox(AABB()) {}
 
-Collider::~Collider()
-{
-    delete boundingBox;
-}
+//Destructor
+Collider::~Collider() = default;
 
 //Getters for member variables
 const Vector2& Collider::getPosition() const
@@ -36,7 +34,7 @@ ColliderType Collider::getType() const
     return type;
 }
 
-AABB* Collider::getAABB() const
+const AABB& Collider::getAABB() const
 {
     return boundingBox;
 }

--- a/engine/src/collisions/CollisionDetection.cpp
+++ b/engine/src/collisions/CollisionDetection.cpp
@@ -7,14 +7,14 @@
 struct Collision;
 
 //Checks if two AABBs are overlapping
-bool CollisionDetection::checkAABBvsAABB(AABB* boxA, AABB* boxB)
+bool CollisionDetection::checkAABBvsAABB(const AABB& boxA, const AABB& boxB)
 {
     //Get mins and maxes
-    Vector2 minA = boxA->getMin();
-    Vector2 maxA = boxA->getMax();
+    Vector2 minA = boxA.min;
+    Vector2 maxA = boxA.max;
 
-    Vector2 minB = boxB->getMin();
-    Vector2 maxB = boxB->getMax();
+    Vector2 minB = boxB.min;
+    Vector2 maxB = boxB.max;
 
     //Check for overlap
     if (maxA.x > minB.x && minA.x < maxB.x && maxA.y > minB.y && minA.y < maxB.y)

--- a/engine/src/collisions/RectCollider.cpp
+++ b/engine/src/collisions/RectCollider.cpp
@@ -7,7 +7,7 @@ RectCollider::RectCollider(Vector2 dimensions, ColliderType type)
     : Collider(ColliderShape::Rectangle, type), width(dimensions.x), height(dimensions.y)
     {
         //Create AABB to enclose rectangle shape
-        boundingBox = new AABB({position.x - width / 2, position.y - height / 2}, {position.x + width / 2, position.y + height / 2});
+        boundingBox = AABB({position.x - width / 2, position.y - height / 2}, {position.x + width / 2, position.y + height / 2});
     }
 
 //Getters for member variables
@@ -43,6 +43,6 @@ void RectCollider::setHeight(float newHeight)
 //Update AABB mins and maxes
 void RectCollider::updateAABB()
 {
-    boundingBox->setMin({position.x - width / 2, position.y - height / 2});
-    boundingBox->setMax({position.x + width / 2, position.y + height / 2});
+    boundingBox.min = {position.x - width / 2, position.y - height / 2};
+    boundingBox.max = {position.x + width / 2, position.y + height / 2};
 }

--- a/engine/src/core/Engine.cpp
+++ b/engine/src/core/Engine.cpp
@@ -147,8 +147,8 @@ void Engine::processCollisions()
                     continue;
 
                 //First check if AABBs are intersecting (Broad phase)
-                AABB* boundingBoxA = colliderA->getAABB();
-                AABB* boundingBoxB = colliderB->getAABB();
+                const AABB boundingBoxA = colliderA->getAABB();
+                const AABB boundingBoxB = colliderB->getAABB();
 
                 if (!CollisionDetection::checkAABBvsAABB(boundingBoxA, boundingBoxB)) continue;
 

--- a/engine/src/core/Vector2.cpp
+++ b/engine/src/core/Vector2.cpp
@@ -1,9 +1,9 @@
-//Class implementation for 2D vectors
+//Implementation for 2D vectors
 
 #include "core/Vector2.hpp"
 
 //Default constructor
-Vector2::Vector2() : x(0), y(0) {}
+Vector2::Vector2() : x(0.0f), y(0.0f) {}
 
 //Constructor with given x and y values
 Vector2::Vector2(float x, float y) : x(x), y(y) {}


### PR DESCRIPTION
Changed Vector2 and AABB classes to structs since they are simple data structures and nothing needs to be private.