### PR TITLE
Update/CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,13 @@
 cmake_minimum_required(VERSION 3.10)
 project(PhysicsEngineProject)
 
+#Allow engine to be built without a demo if specified
+option(BUILD_DEMO "Build the physics engine demo" ON)
+
 #Build engine static library
 add_subdirectory(engine)
 
-#Build the demo executable, which links to the engine library
-add_subdirectory(demo)
+#Build the demo executable unless specified not to
+if(BUILD_DEMO)
+    add_subdirectory(demo)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #For building the physics engine library and demo executable together
 
 #Define project and minimum version of cmake required
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 project(PhysicsEngineProject)
 
 #Build engine static library

--- a/README.md
+++ b/README.md
@@ -49,52 +49,59 @@ A basic 2D physics simulator using C++ and SFML. This project is an ambitious go
 ### Prerequisites
 - **C++ Compiler**: A compiler that supports C++17 (e.g., GCC 10+, Clang 10+, or MSVC 2019+).
 - **CMake**: Version 3.10 or higher.
-- **SFML**: Version 3.0 or higher (for the demo).
 
 ### Building the Project
 
-1. Clone the repository:
+**1. Clone the repository:**
 ```bash
 git clone https://github.com/randerson112/2d_physics_engine.git
 cd 2d_physics_engine
 ```
 
-2. Create a build directory:
-- **On MacOS/Linux**
+**2. Create a build directory:**
+- On MacOS/Linux
 ```bash
 mkdir build
 cd build
 ```
 
-- **On Windows**
+- On Windows
 ```bash
 md build
 cd build
 ```
 
-3. Configure the project with CMake:
+**3. Configure the project with CMake:**
+- Engine with demo
 ```bash
 cmake ..
 ```
 
-4. Build the project:
+- Engine with no demo
+```bash
+cmake -DBUILD_DEMO=OFF ..
+```
+
+**4. Build the project:**
 ```bash
 cmake --build .
-```
+``` 
+
+**Building with the demo will take significantly longer since it needs to fetch and link SFML libraries**
 
 ---
 
 ## Running the Demo
 
-1. Navigate to **build/demo**, there should now be an executable called **PhysicsEngineDemo**
+**1. Navigate to the build/demo directory, there should now be an executable called PhysicsEngineDemo**
 
-2. Run the executable:
-- **On MacOS/Linux**
+**2. Run the executable:**
+- On MacOS/Linux
 ```bash
 ./PhysicsEngineDemo
 ```
 
-- **On Windows**
+- On Windows
 ```bash
 PhysicsEngineDemo.exe
 ```

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ A basic 2D physics simulator using C++ and SFML. This project is an ambitious go
 ## How to Build
 
 ### Prerequisites
-- **C++ Compiler**: A compiler that supports C++20 (e.g., GCC 10+, Clang 10+, or MSVC 2019+).
-- **CMake**: Version 3.3 or higher.
+- **C++ Compiler**: A compiler that supports C++17 (e.g., GCC 10+, Clang 10+, or MSVC 2019+).
+- **CMake**: Version 3.10 or higher.
 - **SFML**: Version 3.0 or higher (for the demo).
 
 ### Building the Project

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -8,8 +8,16 @@ project(PhysicsEngineDemo)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-#Find SFML on system
-find_package(SFML 3 REQUIRED COMPONENTS Graphics Window System)
+#Include FetchContent module
+include(FetchContent)
+
+#Fetch SFML
+FetchContent_Declare(
+    SFML
+    GIT_REPOSITORY https://github.com/SFML/SFML.git
+    GIT_TAG 3.0.0
+)
+FetchContent_MakeAvailable(SFML)
 
 #Create the demo executable
 add_executable(${PROJECT_NAME})

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,11 +1,11 @@
 #For building the demo project
 #Builds the engine static library and links it to the demo automatically
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 project(PhysicsEngineDemo)
 
 #Sets C++ version required
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 #Find SFML on system

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,10 +1,10 @@
 #For building the engine as a static library for linking
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 project(PhysicsEngineLibrary)
 
 #Set C++ version required
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 #Create a static library for the physics engine


### PR DESCRIPTION
Updated CMakeLists to only require CMake 3.10 and C++ 17. The demo now fetches SFML so users do not need it installed. Users also have an option to build without the demo.