### PR TITLE
feat: add .clang-format file and add jetbrains folder to .gitignore

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+BasedOnStyle: Microsoft
+
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+BreakBeforeBraces: Allman
+AllowShortFunctionsOnASingleLine: Inline
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BreakConstructorInitializers: AfterColon
+
+BinPackParameters: false
+BinPackArguments: false
+AlignAfterOpenBracket: DontAlign
+
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+ReflowComments: false
+
+ColumnLimit: 120
+
+SortIncludes: false
+IncludeBlocks: Preserve
+
+AlwaysBreakTemplateDeclarations: No
+NamespaceIndentation: All
+FixNamespaceComments: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 engine/build/
 demo/build/
+.idea
 
 # testing folder
 testing/


### PR DESCRIPTION
Hello Ryan,

I recently discovered and was looking on some ways on how the codebase can be maintained from formatting perspective, I added a file called .clang-formatter which enforces formatting on cross platforms like visual studio and jetbrains ide's, it is not 100% perfect I found some little indexing flaws when I was running it on some files that have classes or namespaces it is reformatting some of the indenting. If find some other little things that can make the code style better you can comment so I can see if it is configured via the added file. If you agree going this way I think we should run the code formatter for all files so we have the same code style on every file or possibly I can create a git hook which runs before commit and reformats the code. #12 