### PR TITLE
Rework collision layers behavior and add collision masks

### DIFF
--- a/engine/include/collisions/Collider.hpp
+++ b/engine/include/collisions/Collider.hpp
@@ -9,6 +9,7 @@
 #include "physics/PhysicsBody.hpp"
 #include "core/Vector2.hpp"
 #include "collisions/AABB.hpp"
+#include <vector>
 
 namespace phys
 {
@@ -50,8 +51,11 @@ namespace phys
         //Bounding box for broad collision detection
         AABB m_boundingBox;
 
-        //Collision layer, only collides with colliders of same layer
-        unsigned int m_collisionLayer;
+        //Collision layers, what layers does this collider belong to
+        std::vector<unsigned int> m_collisionLayers;
+
+        //Collisions masks, what layers does this collider collide with
+        std::vector<unsigned int> m_collisionMasks;
 
         //Update AABB mins and maxes
         virtual void updateAABB() = 0;
@@ -73,7 +77,6 @@ namespace phys
         ColliderShape getShape() const;
         ColliderType getType() const;
         const AABB& getAABB() const;
-        unsigned int getCollisionLayer() const;
 
         //Setters for member variables
         void setPosition(const Vector2& newPosition);
@@ -81,9 +84,20 @@ namespace phys
         void setOffset(const Vector2& newOffest);
         void setParent(PhysicsBody* newParent);
         void setType(ColliderType newType);
-        void setCollisionLayer(unsigned int newLayer);
 
-        //Maybe a method to change the shape of the collider in the future
+        //Collision layers and masks
+        const std::vector<unsigned int>& getCollisionLayers() const;
+        const std::vector<unsigned int>& getCollisionMasks() const;
+        void setCollisionLayers(const std::vector<unsigned int>& newLayers);
+        void setCollisionMasks(const std::vector<unsigned int>& newMasks);
+
+        void addCollisionLayer(unsigned int newLayer);
+        void addCollisionMask(unsigned int newMask);
+        void removeCollisionLayer(unsigned int layer);
+        void removeCollisionMask(unsigned int mask);
+
+        bool isOnLayer(unsigned int layer);
+        bool collidesWithLayer(unsigned int layer);
     };
 }
 

--- a/engine/include/collisions/CollisionDetection.hpp
+++ b/engine/include/collisions/CollisionDetection.hpp
@@ -24,6 +24,9 @@ namespace phys
 
     namespace CollisionDetection
     {
+        //Checks layers and masks of colliders to see if they should collide
+        bool shouldCollide(Collider* colliderA, Collider* colliderB);
+
         //Checks if two AABBs are overlapping
         bool checkAABBvsAABB(const AABB& boxA, const AABB& boxB);
 

--- a/engine/src/collisions/Collider.cpp
+++ b/engine/src/collisions/Collider.cpp
@@ -12,7 +12,8 @@ namespace phys
         m_shape(colliderShape),
         m_type(colliderType),
         m_boundingBox(AABB()),
-        m_collisionLayer(0)
+        m_collisionLayers({0}),
+        m_collisionMasks({0})
     {
     }
 
@@ -60,11 +61,6 @@ namespace phys
         return m_boundingBox;
     }
 
-    unsigned int Collider::getCollisionLayer() const
-    {
-        return m_collisionLayer;
-    }
-
     //Setters for member variables
     void Collider::setPosition(const Vector2& newPosition)
     {
@@ -94,8 +90,60 @@ namespace phys
         m_type = newType;
     }
 
-    void Collider::setCollisionLayer(unsigned int newLayer)
+    //Collision layers and masks
+    const std::vector<unsigned int>& Collider::getCollisionLayers() const
     {
-        m_collisionLayer = newLayer;
+        return m_collisionLayers;
+    }
+
+    const std::vector<unsigned int>& Collider::getCollisionMasks() const
+    {
+        return m_collisionMasks;
+    }
+
+    void Collider::setCollisionLayers(const std::vector<unsigned int>& newLayers)
+    {
+        m_collisionLayers = newLayers;
+    }
+
+    void Collider::setCollisionMasks(const std::vector<unsigned int>& newMasks)
+    {
+        m_collisionMasks = newMasks;
+    }
+
+    void Collider::addCollisionLayer(unsigned int newLayer)
+    {
+        if (std::find(m_collisionLayers.begin(), m_collisionLayers.end(), newLayer) == m_collisionLayers.end())
+            m_collisionLayers.push_back(newLayer);
+    }
+
+    void Collider::addCollisionMask(unsigned int newMask)
+    {
+        if (std::find(m_collisionMasks.begin(), m_collisionMasks.end(), newMask) == m_collisionMasks.end())
+            m_collisionMasks.push_back(newMask);
+    }
+
+    void Collider::removeCollisionLayer(unsigned int layer)
+    {
+        auto it = std::find(m_collisionLayers.begin(), m_collisionLayers.end(), layer);
+        if (it != m_collisionLayers.end())
+            m_collisionLayers.erase(it);
+    }
+
+    void Collider::removeCollisionMask(unsigned int mask)
+    {
+        auto it = std::find(m_collisionMasks.begin(), m_collisionMasks.end(), mask);
+        if (it != m_collisionMasks.end())
+            m_collisionMasks.erase(it);
+    }
+
+    bool Collider::isOnLayer(unsigned int layer)
+    {
+        return std::find(m_collisionLayers.begin(), m_collisionLayers.end(), layer) != m_collisionLayers.end();
+    }
+
+    bool Collider::collidesWithLayer(unsigned int layer)
+    {
+        return std::find(m_collisionMasks.begin(), m_collisionMasks.end(), layer) != m_collisionMasks.end();
     }
 }

--- a/engine/src/collisions/CollisionDetection.cpp
+++ b/engine/src/collisions/CollisionDetection.cpp
@@ -8,6 +8,43 @@ struct Collision;
 
 namespace phys
 {
+    bool CollisionDetection::shouldCollide(Collider* colliderA, Collider* colliderB)
+    {
+        //Get layers and masks
+        const std::vector<unsigned int>& aLayers = colliderA->getCollisionLayers();
+        const std::vector<unsigned int>& aMasks = colliderA->getCollisionMasks();
+
+        const std::vector<unsigned int>& bLayers = colliderB->getCollisionLayers();
+        const std::vector<unsigned int>& bMasks = colliderB->getCollisionMasks();
+
+        bool aWantsCollideB = false;
+
+        //Check if A wants to collide with B
+        for (unsigned int aMask : aMasks)
+        {
+            if (std::find(bLayers.begin(), bLayers.end(), aMask) != bLayers.end())
+            {
+                aWantsCollideB = true;
+                break;
+            }
+        }
+
+        //Return false if A does not mask one of B layers
+        if (!aWantsCollideB)
+            return false;
+
+        //Check if B wants to collide with A
+        for (unsigned int bMask : bMasks)
+        {
+            if (std::find(aLayers.begin(), aLayers.end(), bMask) != aLayers.end())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     //Checks if two AABBs are overlapping
     bool CollisionDetection::checkAABBvsAABB(const AABB& boxA, const AABB& boxB)
     {
@@ -255,8 +292,8 @@ namespace phys
         Collider* colliderA = bodyA->getCollider();
         Collider* colliderB = bodyB->getCollider();
 
-        //If on different collision layers, return early
-        if (colliderA->getCollisionLayer() != colliderB->getCollisionLayer())
+        //Check if they should collide based on layers and masks
+        if (!shouldCollide(colliderA, colliderB))
             return nullptr;
 
         //Get collider shapes

--- a/engine/src/core/PhysicsWorld.cpp
+++ b/engine/src/core/PhysicsWorld.cpp
@@ -121,10 +121,6 @@ namespace phys
                     Collider* colliderA = bodyA->getCollider();
                     Collider* colliderB = bodyB->getCollider();
 
-                    //If different collision layers, no need to check collision
-                    if (colliderA->getCollisionLayer() != colliderB->getCollisionLayer())
-                        continue;
-
                     //Get collider types
                     ColliderType colliderTypeA = colliderA->getType();
                     ColliderType colliderTypeB = colliderB->getType();


### PR DESCRIPTION
Colliders now have a list of collision layers that they belong to and a list of collision masks that they want to collide with