### PR TITLE
Export assets paths from CMakeLists.txt for consistency across environments

### DIFF
--- a/demos/character-movement-demo/CMakeLists.txt
+++ b/demos/character-movement-demo/CMakeLists.txt
@@ -8,6 +8,15 @@ project(CharacterMovementDemo)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+#Set assets path
+set(ASSETS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/assets")
+
+#Generate Config.hpp
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/config.hpp.in
+    ${CMAKE_CURRENT_BINARY_DIR}/config.hpp
+)
+
 #Include FetchContent module
 include(FetchContent)
 
@@ -27,7 +36,7 @@ file(GLOB_RECURSE DEMO_SOURCES src/*.cpp)
 target_sources(${PROJECT_NAME} PRIVATE ${DEMO_SOURCES})
 
 #Set include directory
-target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_include_directories(${PROJECT_NAME} PRIVATE include ${CMAKE_CURRENT_BINARY_DIR})
 
 #Link the physics engine library
 target_link_libraries(${PROJECT_NAME} PRIVATE PhysicsEngineLibrary)

--- a/demos/character-movement-demo/config.hpp.in
+++ b/demos/character-movement-demo/config.hpp.in
@@ -1,0 +1,3 @@
+#pragma once
+
+inline constexpr auto ASSETS_PATH = "@ASSETS_PATH@";

--- a/demos/character-movement-demo/src/CharacterMovementDemo.cpp
+++ b/demos/character-movement-demo/src/CharacterMovementDemo.cpp
@@ -1,4 +1,5 @@
 #include "CharacterMovementDemo.hpp"
+#include "config.hpp"
 
 #include <iostream>
 
@@ -33,7 +34,7 @@ CharacterMovementDemo::CharacterMovementDemo() :
     m_world({DEFAULT_WINDOW_WIDTH / PIXELS_PER_METER, DEFAULT_WINDOW_HEIGHT / PIXELS_PER_METER}),
     m_window(sf::VideoMode({DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT}), "Physics Engine Character Movement Demo"),
     m_player(nullptr),
-    m_font("demos/character-movement-demo/assets/arial.ttf"),
+    m_font(std::string(ASSETS_PATH) + "/arial.ttf"),
     m_coinCounter(m_font),
     m_coins(),
     m_collectedCoinCount(0)

--- a/demos/demo1/CMakeLists.txt
+++ b/demos/demo1/CMakeLists.txt
@@ -8,6 +8,15 @@ project(PhysicsEngineDemo1)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+#Set assets path
+set(ASSETS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/assets")
+
+#Generate Config.hpp
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/config.hpp.in
+    ${CMAKE_CURRENT_BINARY_DIR}/config.hpp
+)
+
 #Include FetchContent module
 include(FetchContent)
 
@@ -27,7 +36,7 @@ file(GLOB_RECURSE DEMO_SOURCES src/*.cpp)
 target_sources(${PROJECT_NAME} PRIVATE ${DEMO_SOURCES})
 
 #Set include directory
-target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_include_directories(${PROJECT_NAME} PRIVATE include ${CMAKE_CURRENT_BINARY_DIR})
 
 #Link the physics engine library
 target_link_libraries(${PROJECT_NAME} PRIVATE PhysicsEngineLibrary)

--- a/demos/demo1/config.hpp.in
+++ b/demos/demo1/config.hpp.in
@@ -1,0 +1,3 @@
+#pragma once
+
+inline constexpr auto ASSETS_PATH = "@ASSETS_PATH@";

--- a/demos/demo1/src/PhysicsEngineDemo.cpp
+++ b/demos/demo1/src/PhysicsEngineDemo.cpp
@@ -1,4 +1,5 @@
 #include "PhysicsEngineDemo.hpp"
+#include "config.hpp"
 #include <iostream>
 
 //Implementation for physics engine demo class
@@ -44,7 +45,7 @@ float getEngineRotation(sf::Angle objectRenderRotation)
 //Constructor
 PhysicsEngineDemo::PhysicsEngineDemo() :
     m_window(sf::VideoMode({DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT}), "Physics Engine Demo"),
-    m_font("../../../demos/demo1/assets/arial.ttf"),
+    m_font(std::string(ASSETS_PATH) + "/arial.ttf"),
     m_fpsText(m_font),
     m_objectCountText(m_font),
     m_world({DEFAULT_WINDOW_WIDTH / PIXELS_PER_METER, DEFAULT_WINDOW_HEIGHT / PIXELS_PER_METER}),


### PR DESCRIPTION
Export the assets paths from cmake to make the path specific to your environment and not a relative path